### PR TITLE
Add homepage navigation and basic pages

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin - VisualBoost</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-white text-gray-900 font-sans p-8">
+  <h1 class="text-3xl font-bold mb-4">Admin</h1>
+  <p>Эта страница предназначена для администраторов.</p>
+  <p><a href="/" class="text-purple-600 hover:underline">Вернуться на главную</a></p>
+</body>
+</html>

--- a/audience.html
+++ b/audience.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Audience - VisualBoost</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-white text-gray-900 font-sans p-8">
+  <h1 class="text-3xl font-bold mb-4">Audience</h1>
+  <p>Эта страница пока находится в разработке.</p>
+  <p><a href="/" class="text-purple-600 hover:underline">Вернуться на главную</a></p>
+</body>
+</html>

--- a/brief.html
+++ b/brief.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Brief - VisualBoost</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-white text-gray-900 font-sans p-8">
+  <h1 class="text-3xl font-bold mb-4">Brief</h1>
+  <p>Эта страница пока находится в разработке.</p>
+  <p><a href="/" class="text-purple-600 hover:underline">Вернуться на главную</a></p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,18 @@
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-white text-gray-900 font-sans">
+  <header class="bg-gray-100 py-4">
+    <div class="max-w-3xl mx-auto text-center">
+      <p class="mb-2">Добро пожаловать в VisualBoost — сервис тестирования карточек товаров.</p>
+      <nav class="space-x-4">
+        <a href="/brief" class="text-purple-600 hover:underline">Brief</a>
+        <a href="/audience" class="text-purple-600 hover:underline">Audience</a>
+        <a href="/upload" class="text-purple-600 hover:underline">Upload</a>
+        <a href="/thank-you" class="text-purple-600 hover:underline">Thank You</a>
+        <a href="/admin" class="text-purple-600 hover:underline">Admin</a>
+      </nav>
+    </div>
+  </header>
   <!-- Hero Section -->
   <section class="min-h-screen flex flex-col justify-center items-center text-center px-6 bg-cover bg-center" style="background-image: url('caver (1).png');">
     <img src="Group 3.png" alt="VisualBoost Logo" class="w-48 h-auto mb-6">

--- a/thank-you.html
+++ b/thank-you.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Thank You - VisualBoost</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-white text-gray-900 font-sans p-8">
+  <h1 class="text-3xl font-bold mb-4">Thank You</h1>
+  <p>Спасибо за использование VisualBoost!</p>
+  <p><a href="/" class="text-purple-600 hover:underline">Вернуться на главную</a></p>
+</body>
+</html>

--- a/upload.html
+++ b/upload.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Upload - VisualBoost</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-white text-gray-900 font-sans p-8">
+  <h1 class="text-3xl font-bold mb-4">Upload</h1>
+  <p>Эта страница пока находится в разработке.</p>
+  <p><a href="/" class="text-purple-600 hover:underline">Вернуться на главную</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add nav bar with page links to `index.html`
- create placeholder pages for `/brief`, `/audience`, `/upload`, `/thank-you`, `/admin`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6868e85b2670832b82ff22a53c2577ea