### PR TITLE
Fix Brief link to Google Form

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <div class="max-w-3xl mx-auto text-center">
       <p class="mb-2">Добро пожаловать в VisualBoost — сервис тестирования карточек товаров.</p>
       <nav class="space-x-4">
-        <a href="/brief" class="text-purple-600 hover:underline">Brief</a>
+        <a href="https://docs.google.com/forms/d/e/1FAIpQLSfVNbYNFirKpuGeiXUTPWNT8WVBulnpS1wSG0a4LNKx5z4iyg/viewform" target="_blank" rel="noopener" class="text-purple-600 hover:underline">Brief</a>
         <a href="https://docs.google.com/forms/d/e/1FAIpQLSdOaCruM81fYsHhjloq404dgncmXi75IqefqTZL-ASdfYQmsQ/viewform" class="text-purple-600 hover:underline" target="_blank" rel="noopener">Audience</a>
         <a href="/upload" class="text-purple-600 hover:underline">Upload</a>
         <a href="/thank-you" class="text-purple-600 hover:underline">Thank You</a>


### PR DESCRIPTION
## Summary
- update the "Brief" button so it opens the Google Form in a new tab

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686a43148494832bb7ff55f9715f5cc1