### PR TITLE
Fix redirect on forms and navigation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
       <a href="https://docs.google.com/forms/d/e/1FAIpQLSfVNbYNFirKpuGeiXUTPWNT8WVBulnpS1wSG0a4LNKx5z4iyg/viewform" target="_blank" rel="noopener" class="text-gray-700 hover:text-purple-600">Brief</a>
       <a href="https://docs.google.com/forms/d/e/1FAIpQLSdOaCruM81fYsHhjloq404dgncmXi75IqefqTZL-ASdfYQmsQ/viewform" target="_blank" rel="noopener" class="text-gray-700 hover:text-purple-600">Audience</a>
       <a href="/upload.html" class="text-gray-700 hover:text-purple-600">Upload</a>
-      <a href="/thankyou.html" class="text-gray-700 hover:text-purple-600">Thank You</a>
+        <a href="/thank-you.html" class="text-gray-700 hover:text-purple-600">Thank You</a>
       <a href="/admin.html" class="text-gray-700 hover:text-purple-600">Admin</a>
     </div>
   </nav>
@@ -74,7 +74,7 @@
         class="form-input mb-3 px-4 py-2 rounded-xl w-full border border-gray-300"
         required
       />
-      <input type="hidden" name="_redirect" value="/thank-you.html" />
+      <input type="hidden" name="_next" value="/thank-you.html" />
       <button
         type="submit"
         class="text-white bg-purple-600 hover:bg-purple-700 px-6 py-3 rounded-xl w-full mt-3 transition duration-200"

--- a/upload.html
+++ b/upload.html
@@ -21,7 +21,7 @@
       <label for="cardB" class="block mb-1">Карточка B:</label>
       <input type="file" name="cardB" id="cardB" accept="image/*" required class="w-full">
     </div>
-    <input type="hidden" name="_redirect" value="/thank-you.html">
+    <input type="hidden" name="_next" value="/thank-you.html">
     <button type="submit" class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded">
       Загрузить карточки
     </button>


### PR DESCRIPTION
## Summary
- fix broken navigation link to Thank You page
- use `_next` for Formspree redirects on forms

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a5e452e9c832b9e3b1c3bfa5b9fb8