### PR TITLE
Add upload form sending data to Airtable

### DIFF
--- a/upload.html
+++ b/upload.html
@@ -1,31 +1,99 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ru">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Upload - VisualBoost</title>
+  <title>Отправка данных</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-white text-gray-900 font-sans p-8">
-  <h1 class="text-3xl font-bold mb-4">Upload</h1>
-  <form action="https://formspree.io/f/xjkrzbja" method="POST" enctype="multipart/form-data" class="space-y-4">
+  <h1 class="text-3xl font-bold mb-4">Отправить данные клиента</h1>
+  <form id="clientForm" class="space-y-4">
     <div>
-      <label for="clientEmail" class="block mb-1">Ваш email:</label>
-      <input type="email" name="clientEmail" id="clientEmail" required class="w-full border rounded p-2">
+      <label for="clientName" class="block mb-1">Имя:</label>
+      <input type="text" id="clientName" required class="w-full border rounded p-2">
     </div>
     <div>
-      <label for="cardA" class="block mb-1">Карточка A:</label>
-      <input type="file" name="cardA" id="cardA" accept="image/*" required class="w-full">
+      <label for="clientEmail" class="block mb-1">Email:</label>
+      <input type="email" id="clientEmail" required class="w-full border rounded p-2">
     </div>
     <div>
-      <label for="cardB" class="block mb-1">Карточка B:</label>
-      <input type="file" name="cardB" id="cardB" accept="image/*" required class="w-full">
+      <label for="clientSurvey" class="block mb-1">Ответ на опрос:</label>
+      <textarea id="clientSurvey" required class="w-full border rounded p-2"></textarea>
     </div>
-    <input type="hidden" name="_next" value="thank-you.html">
-    <button type="submit" class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded">
-      Загрузить карточки
-    </button>
+    <div>
+      <label for="cardA" class="block mb-1">Карта A:</label>
+      <input type="file" id="cardA" accept="image/*" required class="w-full">
+    </div>
+    <div>
+      <label for="cardB" class="block mb-1">Карта B:</label>
+      <input type="file" id="cardB" accept="image/*" required class="w-full">
+    </div>
+    <button type="submit" class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded">Отправить</button>
   </form>
-  <p class="mt-4"><a href="index.html" class="text-purple-600 hover:underline">Вернуться на главную</a></p>
+  <p id="message" class="mt-4 text-green-600 hidden">Данные успешно отправлены!</p>
+
+  <script>
+    async function uploadToCloudinary(file) {
+      const data = new FormData();
+      data.append('file', file);
+      data.append('upload_preset', 'YOUR_UPLOAD_PRESET');
+      const res = await fetch('https://api.cloudinary.com/v1_1/YOUR_CLOUD_NAME/image/upload', {
+        method: 'POST',
+        body: data
+      });
+      const json = await res.json();
+      return json.secure_url;
+    }
+
+    document.getElementById('clientForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const name = document.getElementById('clientName').value.trim();
+      const email = document.getElementById('clientEmail').value.trim();
+      const survey = document.getElementById('clientSurvey').value.trim();
+      const cardA = document.getElementById('cardA').files[0];
+      const cardB = document.getElementById('cardB').files[0];
+      const message = document.getElementById('message');
+      message.classList.add('hidden');
+
+      try {
+        const [cardAUrl, cardBUrl] = await Promise.all([
+          uploadToCloudinary(cardA),
+          uploadToCloudinary(cardB)
+        ]);
+
+        const payload = {
+          records: [{
+            fields: {
+              fldaUiQ39NYvxUMcVysXUc: name,
+              flduf4AsnhGYBbihrYBBihr: email,
+              fldNewmetaECo8cDCx: survey,
+              fldpA6ksdc76ODrDft: [{ url: cardAUrl }],
+              fldJ5vvb0DHnNwvrdK: [{ url: cardBUrl }]
+            }
+          }]
+        };
+
+        const resp = await fetch('https://api.airtable.com/v0/VisualBoost/tblSGTrooc6X7tuz', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer YOUR_AIRTABLE_TOKEN'
+          },
+          body: JSON.stringify(payload)
+        });
+
+        if (!resp.ok) throw new Error('Request failed');
+
+        message.textContent = 'Данные успешно отправлены!';
+        message.classList.remove('hidden');
+      } catch (err) {
+        message.textContent = 'Ошибка при отправке данных';
+        message.classList.remove('text-green-600');
+        message.classList.add('text-red-600');
+        message.classList.remove('hidden');
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement new upload.html form for client data
- collect name, email, survey answer and two card images
- upload images to Cloudinary then POST to Airtable

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a69422e54832b93656b8e34be1e5d